### PR TITLE
Fix ipv4 is undefined

### DIFF
--- a/lib/helper/network.js
+++ b/lib/helper/network.js
@@ -11,7 +11,9 @@ const getNetworkAddress = () => {
     if (!interfaceDetails) { continue; }
     for (const details of interfaceDetails) {
       const { address, family, internal } = details;
-      if (family === 'IPv4' && !internal) { return address; }
+      if ((family === 'IPv4' || family === 4) && !internal) {
+        return address;
+      }
     }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "directory-serve",
-  "version": "1.1.6",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "directory-serve",
-      "version": "1.1.6",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "express": "^4.18.2",
@@ -27,7 +27,7 @@
         "nodemon": "^2.0.20"
       },
       "engines": {
-        "node": ">=16.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/@eslint/eslintrc": {


### PR DESCRIPTION
Ipv4 undefined is fixed. os.networkInterfaces() in node js 18 now sets the family to either 4 or 6 instead of a string.  

This issue is fixed #17 